### PR TITLE
Fix/#01 디바이스 별 화면 비율 최적화

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,126 +1,13 @@
-#root {
-  min-height: 100vh;      /* 화면 전체 높이 확보 */
-  display: flex;          /* 중앙 정렬을 위한 flex 사용 */
-  justify-content: center;
-  align-items: center;
-  font-family: 'Montserrat';
-  background: #f5f5f5;    /* (선택) 전체 배경색 */
-}
+/* CSS 파일들을 import하는 메인 파일 */
 
-.menu-fixed {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0 20px;
-  gap: 22px;
-  width: 100%;
-  height: 69px;
-  background: #000000;
-}
+/* 기본 레이아웃 및 공통 요소 */
+@import './styles/base.css';
 
-.app-frame {
-  width: 430px;
-  min-height: 1000px;     /* 모바일에서 세로로 꽉 차게 */
-  background: #fff;       /* 앱 배경색 */
-  box-shadow: 0 0 10px rgba(0,0,0,0.08); /* (선택) 그림자 */
-  overflow: hidden;       /* (선택) 내용 넘침 방지 */
-  display: flex;
-  flex-direction: column;
-}
+/* 재사용 가능한 공통 컴포넌트 */
+@import './styles/components.css';
 
-/* 상품 목록 페이지 스타일 */
-.product-list-page {
-  flex: 1;
-  padding: 16px;
-  background: #fff;
-}
+/* 페이지별 스타일 */
+@import './styles/pages/products.css';
 
-.product-list-header {
-  margin-bottom: 40px;
-}
-
-.product-list-header h1 {
-  font-size: 1.5rem;
-  font-weight: bold;
-  margin-bottom: 8px;
-  color: #333;
-}
-
-.product-list-header p {
-  color: #666;
-  font-size: 0.9rem;
-}
-
-.product-list-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-}
-
-.product-card {
-  background: #fff;
-  border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  transition: transform 0.2s ease;
-}
-
-.product-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-}
-
-.product-image {
-  width: 100%;
-  height: 120px;
-  object-fit: cover;
-  border-radius: 8px;
-  margin-bottom: 8px;
-}
-
-.product-brand {
-  font-weight: bold;
-  font-size: 0.9rem;
-  margin-bottom: 4px;
-  color: #333;
-}
-
-.product-desc {
-  color: #666;
-  font-size: 0.77rem;
-  margin-bottom: 8px;
-  line-height: 1.3;
-}
-
-.product-price {
-  font-weight: bold;
-  font-size: 0.9rem;
-  margin-bottom: 8px;
-  color: #333;
-}
-
-.cart-btn {
-  background: #000;
-  color: #fff;
-  border: none;
-  border-radius: 30px;
-  padding: 3px 15px;
-  font-size: 0.6rem;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-  align-self: first baseline;
-}
-
-.cart-btn:hover {
-  background: #333;
-}
-
-
-.cart-btn.clicked {
-  background: #D8D8D8;
-  color: #fff;
-}
+/* 반응형 미디어 쿼리 */
+@import './styles/responsive.css';

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,9 +30,23 @@ function App() {
 
   return (
     <div className="app-frame">
-      <nav className="menu-fixed" style={{position: 'relative', width: '100%', height: 69, display: 'flex', alignItems: 'center', justifyContent: 'flex-end', padding: '0 20px', boxSizing: 'border-box'}}>
+      <nav className="menu-fixed">
         {/* 메뉴바 배경 SVG */}
-        <svg width="430" height="69" viewBox="0 0 430 69" fill="none" xmlns="http://www.w3.org/2000/svg" style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', zIndex: 0}}>
+        <svg
+          width="100%"
+          height="100%"
+          viewBox="0 0 430 69"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            zIndex: 0
+          }}
+        >
           <rect width="430" height="69" fill="black"/>
         </svg>
         {/* 장바구니+뱃지 */}

--- a/src/index.css
+++ b/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -30,7 +30,30 @@
   min-height: 100vh;
   background: #fff;                        /* 앱 배경색 */
   box-shadow: 0 0 10px rgba(0,0,0,0.08);   /* 그림자 */
-  overflow: hidden;                          /* 내용 넘침 방지 */
+  overflow-x: hidden;                          /* 내용 넘침 방지 */
+  overflow-y: auto;                          /* 내용 넘침 방지 */
   display: flex;
   flex-direction: column;
+  /* 스크롤바 스타일링 (WebKit 기반 브라우저) */
+  scrollbar-width: thin;                    /* Firefox */
+  scrollbar-color: #888 #f1f1f1;           /* Firefox */
+}
+
+/* WebKit 기반 브라우저 스크롤바 스타일링 */
+.app-frame::-webkit-scrollbar {
+  width: 8px;
+}
+
+.app-frame::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 4px;
+}
+
+.app-frame::-webkit-scrollbar-thumb {
+  background: #888;
+  border-radius: 4px;
+}
+
+.app-frame::-webkit-scrollbar-thumb:hover {
+  background: #555;
 }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,0 +1,36 @@
+/* 기본 레이아웃 및 공통 요소 */
+
+#root {
+  min-height: 100vh;        /* 화면 전체 높이 확보 */
+  display: flex;            /* flex 사용 */
+  font-family: 'Montserrat';
+  background: #f5f5f5;    /* 전체 배경색 */
+}
+
+.menu-fixed {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 20px;
+  gap: 22px;
+  width: 100%;
+  height: 60px;
+  min-height: 60px;
+  background: #000000;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  box-sizing: border-box;
+}
+
+.app-frame {
+  width: 100%;
+  height: 100vh;
+  min-height: 100vh;
+  background: #fff;                        /* 앱 배경색 */
+  box-shadow: 0 0 10px rgba(0,0,0,0.08);   /* 그림자 */
+  overflow: hidden;                          /* 내용 넘침 방지 */
+  display: flex;
+  flex-direction: column;
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,0 +1,98 @@
+/* 재사용 가능한 공통 컴포넌트 */
+
+.product-list-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.product-card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  transition: transform 0.2s ease;
+  height: 280px;
+  min-height: 280px;
+  max-height: 280px;
+  box-sizing: border-box;
+}
+
+.product-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+.product-image {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 8px;
+  margin-bottom: 8px;
+  flex-shrink: 0;
+}
+
+.product-brand {
+  font-weight: bold;
+  font-size: 0.9rem;
+  margin-bottom: 4px;
+  color: #333;
+  flex-shrink: 0;
+}
+
+.product-desc {
+  color: #666;
+  font-size: 0.77rem;
+  margin-bottom: 8px;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-height: 0;
+
+  /* WebKit 지원 (Chrome, Safari, Edge) */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  
+  /* 표준 속성 (Firefox 등) */
+  line-clamp: 2;
+  max-lines: 2;
+  
+  /* 폴백: 최대 높이로 제한 */
+  max-height: 2.6em; /* line-height: 1.3 × 2줄 */
+}
+
+.product-price {
+  font-weight: bold;
+  font-size: 0.9rem;
+  margin-bottom: 8px;
+  color: #333;
+  flex-shrink: 0;
+}
+
+.cart-btn {
+  background: #000;
+  color: #fff;
+  border: none;
+  border-radius: 30px;
+  padding: 3px 15px;
+  font-size: 0.6rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  align-self: flex-start;
+  flex-shrink: 0;
+  margin-top: auto;
+}
+
+.cart-btn:hover {
+  background: #333;
+}
+
+.cart-btn.clicked {
+  background: #D8D8D8;
+  color: #fff;
+}

--- a/src/styles/pages/cart.css
+++ b/src/styles/pages/cart.css
@@ -1,0 +1,82 @@
+/* 장바구니 페이지 전용 스타일 */
+
+.cart-page {
+  flex: 1;
+  padding: 16px;
+  background: #fff;
+}
+
+.cart-header {
+  margin-bottom: 30px;
+  border-bottom: 2px solid #f0f0f0;
+  padding-bottom: 15px;
+}
+
+.cart-header h1 {
+  font-size: 1.8rem;
+  font-weight: bold;
+  color: #333;
+  margin: 0;
+}
+
+.cart-item {
+  display: flex;
+  align-items: center;
+  padding: 15px 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.cart-item-image {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 8px;
+  margin-right: 15px;
+}
+
+.cart-item-details {
+  flex: 1;
+}
+
+.cart-item-brand {
+  font-weight: bold;
+  font-size: 1rem;
+  color: #333;
+  margin-bottom: 5px;
+}
+
+.cart-item-price {
+  font-size: 1.1rem;
+  color: #000;
+  font-weight: bold;
+}
+
+.cart-total {
+  margin-top: 30px;
+  padding: 20px;
+  background: #f8f8f8;
+  border-radius: 12px;
+  text-align: right;
+}
+
+.cart-total h3 {
+  font-size: 1.2rem;
+  margin-bottom: 10px;
+  color: #333;
+}
+
+.checkout-btn {
+  background: #000;
+  color: #fff;
+  border: none;
+  border-radius: 30px;
+  padding: 12px 30px;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.checkout-btn:hover {
+  background: #333;
+}

--- a/src/styles/pages/products.css
+++ b/src/styles/pages/products.css
@@ -1,0 +1,187 @@
+/* 상품 목록 페이지 전용 스타일 */
+
+.product-list-page {
+  flex: 1;
+  padding: 16px;
+  background: #fff;
+}
+
+.product-list-header {
+  margin-bottom: 40px;
+}
+
+.product-list-header h1 {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 8px;
+  color: #333;
+}
+
+.product-list-header p {
+  color: #666;
+  font-size: 0.9rem;
+}
+
+/* 상품 페이지 반응형 스타일 */
+
+/* 작은 화면 */
+@media (max-width: 480px) {
+  .product-list-page {
+    padding: 12px;
+  }
+  
+  .product-list-grid {
+    gap: 12px;
+  }
+  
+  .product-card {
+    height: 260px;
+    min-height: 260px;
+    max-height: 260px;
+    padding: 10px;
+  }
+  
+  .product-image {
+    height: 100px;
+  }
+  
+  .product-desc {
+    font-size: 0.7rem;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    max-lines: 2;
+    max-height: 2.6em;
+  }
+}
+
+/* 세로모드 orientation 테스트용 (width 기반) */
+@media (min-width: 481px) and (max-width: 1180px) {
+  .product-list-grid {
+    grid-template-columns: repeat(3, 1fr) !important;
+    gap: 16px;
+  }
+  
+  .product-card {
+    height: 280px;
+    min-height: 280px;
+  }
+  
+  .product-image {
+    height: 140px;
+  }
+  
+  .product-list-header h1 {
+    font-size: 1.8rem;
+  }
+  
+  .product-list-header p {
+    font-size: 1rem;
+  }
+}
+
+/* 가로모드 orientation 테스트용 (width 기반) */
+@media (min-width: 1024px) and (max-width: 1650px) {
+  .product-list-grid {
+    grid-template-columns: repeat(4, 1fr) !important;
+    gap: 24px;
+  }
+  
+  .product-card {
+    height: 280px;
+    min-height: 280px;
+  }
+  
+  .product-image {
+    height: 120px;
+  }
+  
+  .menu-fixed {
+    height: 55px;
+    padding: 0 24px;
+  }
+}
+
+/* 실제 기기 세로모드 */
+@media (orientation: portrait) and (min-width: 481px) {
+  /* 세로모드에서 추가 조정이 필요한 경우 */
+}
+
+/* 실제 기기 가로모드 */
+@media (orientation: landscape) and (min-width: 1024px) {
+  /* 가로모드에서 추가 조정이 필요한 경우 */
+}
+
+/* 데스크톱 */
+/* @media (min-width: 769px) {
+  
+  
+  .product-list-grid {
+    gap: 20px;
+  }
+  
+  .product-card {
+    height: 300px;
+    min-height: 300px;
+  }
+  
+  .product-image {
+    height: 130px;
+  }
+  
+  .product-list-header h1 {
+    font-size: 1.8rem;
+  }
+  
+  .product-list-header p {
+    font-size: 1rem;
+  }
+  
+  .menu-fixed {
+    height: 65px;
+    padding: 0 28px;
+  }
+} */
+
+/* 세로모드 */
+@media (orientation: portrait) {
+  .product-list-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+  
+  .product-card {
+    height: 260px;
+    min-height: 260px;
+  }
+  
+  .product-image {
+    height: 100px;
+  }
+  
+  .menu-fixed {
+    height: 60px;
+    padding: 0 16px;
+  }
+}
+
+/* 가로모드 */
+@media (orientation: landscape) {
+  .product-list-grid {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+  }
+  
+  .product-card {
+    height: 300px;
+    min-height: 300px;
+  }
+  
+  .product-image {
+    height: 140px;
+  }
+  
+  .menu-fixed {
+    height: 50px;
+    padding: 0 24px;
+  }
+}

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -1,0 +1,31 @@
+/* 공통 반응형 레이아웃 */
+
+/* 작은 화면에서의 공통 조정 */
+@media (max-width: 480px) {
+  .app-frame {
+    box-shadow: none;
+    border-radius: 0;
+  }
+  
+  .menu-fixed {
+    padding: 0 16px;
+    height: 60px;
+    min-height: 60px;
+  }
+}
+
+/* 큰 화면 공통 */
+@media (min-width: 768px) {
+  .app-frame {
+    margin: 0 auto;
+    box-shadow: 0 0 20px rgba(0,0,0,0.1);
+  }
+}
+
+/* 초대형 데스크톱 공통 */
+/* @media (min-width: 1200px) {
+  .app-frame {
+    width: 500px;
+    height: 1000px;
+  }
+} */


### PR DESCRIPTION
# 🔗 연관된 이슈

이슈번호: #01

---

# ✏️ 작업 내용

## css 파일 역할 분담 
base.css: 기본 레이아웃 및 공통 요소
components.css: 재사용 가능한 공통 컴포넌트
pages/products.css: 상품 페이지 전용 스타일 + 반응형
responsive.css: 앱 전체의 공통 반응형 + 조건부 중앙 정렬
App.css: CSS 파일들을 import하는 메인 파일

## index.css

✅ body의 display: flex 제거
✅ body의 place-items: center 제거
✅ body의 min-width: 320px 유지
✅ body의 min-height: 100vh 유지

## App.css

###  base.css

✅ #root의 justify-content: center 제거
✅ #root의 align-items: center 제거
✅ #root의 display: flex는 유지 (조건부 중앙 정렬을 위해)
✅ .app-frame의 margin: 0 auto 제거
✅ .app-frame의 width: min(430px, 100%) → width: 100%로 변경
✅ .app-frame의 height: min(932px, 100vh) → height: 100vh로 변경
✅ .app-frame의 box-shadow, overflow, display: flex 유지

### product.css

#### 태블릿 테스트용 미디어 쿼리 (width 기반)
✅ 세로모드: (min-width: 481px) and (max-width: 1180px)
✅ 가로모드: (min-width: 1024px) and (max-width: 1650px)
✅ 실제 기기 세로모드/가로모드 전환 미디어 쿼리 별도 구현 (orientation 기반)


### responsive.css

#### 조건부 중앙 정렬
✅ 작은 화면 (≤480px): justify-content: flex-start, align-items: flex-start
✅ 중간 화면 (481px~767px): justify-content: center, align-items: center
✅ 큰 화면 (≥768px): justify-content: center, align-items: center

#### 미디어 쿼리 충돌 
✅ !important 사용으로 CSS 우선순위 문제 해결
✅ grid-template-columns 변경 시 !important 적용
✅ max-width 설정 시 !important 적용

---

# 결과
.app-frame이 화면 전체 너비 사용
불필요한 오른쪽 여백 없음
자연스러운 레이아웃
CSS 파일별 역할 분담으로 유지보수성 향상
새로운 페이지 추가 시 확장성 확보

# 📸 스크린샷
<table>
  <tr> 아이폰 SE
    <td style="width: 50%;">
      <img width="708" height="1052" alt="image" src="https://github.com/user-attachments/assets/f3205013-cbc9-4e43-a2cb-876451b1fc03" />
    </td>
    <td style="width: 50%;">
      <img width="1006" height="667" alt="image" src="https://github.com/user-attachments/assets/15fe67fa-4de5-4cea-b267-a843ea9b210f" />
    </td>
  </tr>
</table>

<table>
  <tr> 아이패드 Air
    <td style="width: 50%;">
      <img width="1230" height="1051" alt="image" src="https://github.com/user-attachments/assets/4550d45a-dbe2-440e-9ea4-4f695811cdb1" />
    </td>
    <td style="width: 50%;">
      <img width="1770" height="1046" alt="image" src="https://github.com/user-attachments/assets/fab8f18c-a163-41be-a83c-2b44dcdaa7f4" />
    </td>
  </tr>
</table>




---

# 💬 리뷰 포인트
 Chrome 개발자도구에서 확실한 레이아웃 테스트 가능
(Asus Zenbook flip 제외)

---

# 🗒️ 기타 참고 사항

애플 디바이스의 노치 및 다이나믹 아일랜드를 고려한 레이아웃 미구현
https://daram-tree.tistory.com/213
https://www.reddit.com/r/reactnative/comments/yrzh3f/is_there_a_way_to_test_my_react_native_app_for/?tl=ko
https://blog.codemagic.io/how-to-build-react-native-ios-app-on-windows/
https://stackoverflow.com/questions/50778011/building-expo-app-for-ios-with-windows
